### PR TITLE
temporary fix for german umlaut

### DIFF
--- a/src/tts.py
+++ b/src/tts.py
@@ -138,6 +138,12 @@ def bandpass_filter(audio, low_freq, high_freq, sample_rate, order=5):
     filtered_audio = lfilter(numerator, denominator, audio)
     return filtered_audio
 
+def replace_umlaut_in_string(text, args_dict={'ä': 'ae', 'ö':'oe', 'ü':'ue', 'Ä':'Ae', 'Ö':'Oe', 'Ü':'Ue'}):
+    '''Replace German Umlaut with ae, oe, ue'''
+    for key in args_dict.keys():
+        text = text.replace(key, str(args_dict[key]))
+    return text
+
 def convert_with_telephone_filter(output_directory, fname):
     """Apply telephone-like filter on the generated training data
     Args:
@@ -168,8 +174,9 @@ def main(df, output_directory, custom=True, telephone=True):
     os.makedirs(f'{output_directory}/tts_generated/', exist_ok=True)
     audio_synth = []
     for index, row in df.iterrows():
+        # Temporary workaround for umlaut
         try:
-            app = TextToSpeech(pa.tts_key, pa.tts_language, pa.tts_font, pa.tts_region, row['text'])
+            app = TextToSpeech(pa.tts_key, pa.tts_language, pa.tts_font, pa.tts_region, replace_umlaut_in_string(row['text']))
             app.get_token(pa.tts_region, pa.tts_key)
             fname = app.save_audio(pa.tts_region, pa.tts_resource_name, output_directory, pa.tts_language, pa.tts_font)
             if custom:


### PR DESCRIPTION
Fixed problem with German Umlaut in TTS module, issue identified by Gregor.

See my comment:
"Hi Gregor, thanks again for bringing this up. The reason for this issue is a mix of an API and SDK change. Back then, it also worked with ä, ö... in the text, but not it is apparently no longer supported. I temporarily fixed this by introducing a normalization function. However, an upgrade to the newest SDK version is necessary, which I will tackle within the next 14 days. Cheers, Timm"